### PR TITLE
Add scripts and files to allow running WireMock standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 /build
 /captures
 .externalNativeBuild
+.classpath
+.project
+.settings
+vendor/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Network mocking for testing the WordPress mobile apps
 
 ## Usage ##
 
+### Android
+
 To use this library in your project, you must set it up as a subtree.
 From the root of your main project, add the subtree:
 
@@ -32,6 +34,16 @@ dependencies {
     androidTestImplementation project(path:':libs:mocks:WordPressMocks')
 }
 ```
+
+### Standalone
+
+To start the WireMock server as a standalone process, you can run it with this command:
+
+```
+./scripts/start.sh 8282
+```
+
+Here `8282` is the port to run the server on. It can now be accessed from `http://localhost:8282`.
 
 ## Contributing ##
 

--- a/WordPressMocks.podspec
+++ b/WordPressMocks.podspec
@@ -1,0 +1,10 @@
+Pod::Spec.new do |s|
+  s.name           = 'WordPressMocks'
+  s.version        = '0.0.1'
+  s.summary        = 'Network mocking for testing the WordPress mobile apps.'
+  s.homepage       = 'https://github.com/wordpress-mobile/WordPressMocks'
+  s.license        = { type: 'GPLv2', file: 'LICENSE.md' }
+  s.author         = { 'James Treanor' => 'jtreanor3@gmail.com' }
+  s.source         = { git: "https://github.com/wordpress-mobile/WordPressMocks.git", :tag => s.version.to_s }
+  s.preserve_paths = 'WordPressMocks/src', 'scripts'
+end

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$SCRIPT_DIR/.."
+
+WIREMOCK_VERSION="2.23.2"
+WIREMOCK_JAR="vendor/wiremock-standalone-${WIREMOCK_VERSION}.jar"
+
+if [ ! -f "$WIREMOCK_JAR" ]; then
+    mkdir -p "vendor" && cd "vendor"
+    curl -O -J "http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
+    cd ..
+fi
+
+# Use provided port, or default to 8282
+PORT="${1:-8282}"
+
+# Start WireMock server. See http://wiremock.org/docs/running-standalone/
+java -jar "${WIREMOCK_JAR}" --port "$PORT" \
+                            --global-response-templating \
+                            --root-dir src/main/assets/mocks

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+# Use provided port, or default to 8282
+PORT="${1:-8282}"
+
+echo "Shutting down WireMock server ..."
+
+# Shutdown the WireMock server. See http://wiremock.org/docs/running-standalone/#shutting-down
+curl -X POST "http://localhost:8282/__admin/shutdown"


### PR DESCRIPTION
This is the first PR on this repo, the contents which have been extracted from WordPress-Android.

The changes here allow running the mocks as a standalone process. We will use this for WPiOS.

To test:

- `./scripts/start.sh` should start the WireMock server without errors.
- In a separate terminal window, `./scripts/stop.sh` should stop the WireMock server.
- `pod lib lint WordPressMocks.podspec --verbose` should pass.