### PR TITLE
Allow empty client_secret in /oauth2/token

### DIFF
--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/oauth2_token-error.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/oauth2_token-error.json
@@ -10,7 +10,7 @@
                 "matches": ".*password=invalidPswd(&.*|$)"
             },
             {
-                "matches": ".*client_secret=[^&]+.*"
+                "matches": ".*client_secret=.*"
             }
         ]
     },

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/oauth2_token.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/oauth2_token.json
@@ -10,7 +10,7 @@
                 "matches": ".*password=((?!invalidPswd)[^&])+(&.*|$)"
             },
             {
-                "matches": ".*client_secret=[^&]+.*"
+                "matches": ".*client_secret=.*"
             }
         ]
     },


### PR DESCRIPTION
This is a very small change to allow the mocks to work if there are no credentials set up, such as when running on CI.