### PR TITLE
Update /connect/site-info mock to allow *.wordpress.com urls

### DIFF
--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v11_connect_site-info_WordPress.com.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v11_connect_site-info_WordPress.com.json
@@ -4,14 +4,14 @@
         "urlPath": "/rest/v1.1/connect/site-info",
         "queryParameters": {
             "url": {
-                "equalTo": "https://WordPress.com"
+                "matches": "https://(.+\\.)?wordpress\\.com"
             }
         }
     },
     "response": {
-        "status": 403,
+        "status": 200,
         "jsonBody": {
-            "urlAfterRedirects": "https://WordPress.com",
+            "urlAfterRedirects": "{{request.requestLine.query.url}}",
             "exists": true,
             "isWordPress": true,
             "hasJetpack": false,


### PR DESCRIPTION
Updating mock for `/connect/site-info` to accept urls such as `https://e2eflowtestingmobile.wordpress.com`.

With the latest changes, this was causing errors on WPiOS.