### PR TITLE
Update mocks for WordPress iOS signup test

### DIFF
--- a/WordPressMocks.podspec
+++ b/WordPressMocks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name           = 'WordPressMocks'
-  s.version        = '0.0.3'
+  s.version        = '0.0.5'
   s.summary        = 'Network mocking for testing the WordPress mobile apps.'
   s.homepage       = 'https://github.com/wordpress-mobile/WordPressMocks'
   s.license        = { type: 'GPLv2', file: 'LICENSE.md' }

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available.json
@@ -10,7 +10,9 @@
     },
     "response": {
         "status": 200,
-        "body": true,
+        "jsonBody": {
+            "available": true
+        },
         "headers": {
             "Content-Type": "text/javascript",
             "Connection": "keep-alive"

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPath": "/is-available/email/",
+        "urlPattern": "/is-available/email(/)?($|\\?.*)",
         "queryParameters": {
             "q": {
                 "matches": "^e2eflowsignuptestingmobile@example.com$"

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_not_available.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_not_available.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPath": "/is-available/email(/)?($|\\?.*)",
+        "urlPattern": "/is-available/email(/)?($|\\?.*)",
         "queryParameters": {
             "q": {
                 "matches": "^(?!e2eflowsignuptestingmobile@example.com).*$"

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_not_available.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_not_available.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPath": "/is-available/email/",
+        "urlPath": "/is-available/email(/)?($|\\?.*)",
         "queryParameters": {
             "q": {
                 "matches": "^(?!e2eflowsignuptestingmobile@example.com).*$"

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/magic_link-signup.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/magic_link-signup.json
@@ -1,6 +1,6 @@
 {
     "scenarioName": "auth",
-    "requiredScenarioState": "logged-in",
+    "requiredScenarioState": "signed-up",
     "request": {
         "method": "GET",
         "urlPath": "/magic-link"
@@ -9,7 +9,7 @@
         "status": 302,
         "headers": {
             "Content-Type": "text/html;charset=utf-8",
-            "Location": "{{request.query.scheme}}://magic-login?token=valid_token"
+            "Location": "{{request.query.scheme}}://magic-login?token=valid_token&new_user=1"
         }
     }
 }

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v11_auth_send-signup-email.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v11_auth_send-signup-email.json
@@ -2,7 +2,7 @@
     "scenarioName": "auth",
     "newScenarioState": "signed-up",
     "request": {
-        "urlPath": "/rest/v1.1/auth/send-signup-email/",
+        "urlPath": "/rest/v1.1/auth/send-signup-email.*",
         "method": "POST"
     },
     "response": {

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v11_auth_send-signup-email.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v11_auth_send-signup-email.json
@@ -2,7 +2,7 @@
     "scenarioName": "auth",
     "newScenarioState": "signed-up",
     "request": {
-        "urlPath": "/rest/v1.1/auth/send-signup-email.*",
+        "urlPattern": "/rest/v1.1/auth/send-signup-email.*",
         "method": "POST"
     },
     "response": {

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me.json
@@ -1,7 +1,7 @@
 {
     "scenarioName": "auth",
     "request": {
-        "urlPattern": "/rest/v1.1/me(\\?|/|$).*",
+        "urlPattern": "/rest/v1.1/me($|\\?.*|\/(?!settings|sites))",
         "method": "GET"
     },
     "response": {

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me.json
@@ -1,7 +1,7 @@
 {
     "scenarioName": "auth",
     "request": {
-        "urlPattern": "/rest/v1.1/me($|\\?.*|\/(?!settings|sites))",
+        "urlPattern": "/rest/v1.1/me(/)?($|\\?.*)",
         "method": "GET"
     },
     "response": {

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_signup.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_signup.json
@@ -2,7 +2,7 @@
     "scenarioName": "auth",
     "requiredScenarioState": "signed-up",
     "request": {
-        "urlPattern": "/rest/v1.1/me($|\\?.*|\/(?!settings|sites))",
+        "urlPattern": "/rest/v1.1/me(/)?($|\\?.*)",
         "method": "GET"
     },
     "response": {

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_signup.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_signup.json
@@ -2,7 +2,7 @@
     "scenarioName": "auth",
     "requiredScenarioState": "signed-up",
     "request": {
-        "urlPath": "/rest/v1.1/me/",
+        "urlPattern": "/rest/v1.1/me($|\\?.*|\/(?!settings|sites))",
         "method": "GET"
     },
     "response": {


### PR DESCRIPTION
This PR updates the mocks as needed for a signup test on WordPress iOS (see https://github.com/wordpress-mobile/WordPress-iOS/pull/11931).

To test:

* Follow the test steps in https://github.com/wordpress-mobile/WordPress-iOS/pull/11931 to test these changes in the WordPress iOS tests.