### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+#### Proposed Changes
+
+
+
+#### To Test
+
+<!-- Please include instructions for testing these changes on both WordPress apps.
+     This can be a link to a PR in that app's repo using the proposed changes.  -->
+
+* WordPress Android: 
+* WordPress iOS: 
+
+cc @wordpress-mobile/platform-9 


### PR DESCRIPTION
This adds a PR template that explicitly asks for testing instructions on both WPAndroid and WPiOS. I also included a ping to the Platform9 team since I imagine we'll want to be aware of any changes (do you think that's overkill?).