### PR TITLE
CircleCI: Add config to validate and publish pod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+
+orbs:
+  # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
+  ios: wordpress-mobile/ios@0.0.35
+
+workflows:
+  wordpress_mocks:
+    jobs:
+      - ios/validate-podspec:
+          name: Validate Podspec
+          sources: https://cdn.cocoapods.org/
+          xcode-version: "11.0.0"
+          podspec-path: WordPressMocks.podspec
+      - ios/publish-podspec:
+          name: Publish to Trunk
+          xcode-version: "11.0.0"
+          podspec-path: WordPressMocks.podspec
+          post-to-slack: true
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org' do
-  gem 'cocoapods', '1.6.1'
+  gem 'cocoapods', '1.7.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.0)
+    CFPropertyList (3.0.1)
     activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     atomos (0.1.3)
-    claide (1.0.2)
-    cocoapods (1.6.1)
+    claide (1.0.3)
+    cocoapods (1.7.5)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.6.1)
-      cocoapods-deintegrate (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.7.5)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
@@ -22,13 +22,13 @@ GEM
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
-      fourflusher (>= 2.2.0, < 3.0)
+      fourflusher (>= 2.3.0, < 3.0)
       gh_inspector (~> 1.0)
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.8.1, < 2.0)
-    cocoapods-core (1.6.1)
+      xcodeproj (>= 1.10.0, < 2.0)
+    cocoapods-core (1.7.5)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
@@ -38,19 +38,19 @@ GEM
       nap
     cocoapods-search (1.0.0)
     cocoapods-stats (1.1.0)
-    cocoapods-trunk (1.3.1)
+    cocoapods-trunk (1.4.1)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.1.0)
     colored2 (3.1.2)
     concurrent-ruby (1.1.5)
     escape (0.0.4)
-    fourflusher (2.2.0)
+    fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    minitest (5.11.3)
+    minitest (5.12.2)
     molinillo (0.6.6)
     nanaimo (0.2.6)
     nap (1.1.0)
@@ -59,7 +59,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.9.0)
+    xcodeproj (1.12.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -70,7 +70,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.6.1)!
+  cocoapods (= 1.7.5)!
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/WordPressMocks.podspec
+++ b/WordPressMocks.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
   s.name           = 'WordPressMocks'
   s.version        = '0.0.6'
+  s.platform       = :ios
   s.summary        = 'Network mocking for testing the WordPress mobile apps.'
   s.homepage       = 'https://github.com/wordpress-mobile/WordPressMocks'
   s.license        = { type: 'GPLv2', file: 'LICENSE.md' }


### PR DESCRIPTION
#### Proposed Changes

Adding a CircleCI config to validate the podspec and publish the pod when tagged.

#### To Test

Checks are green.
