### PR TITLE
Fix the broken standalone wiremock issue

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,7 +10,7 @@ WIREMOCK_JAR="${VENDOR_DIR}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
 
 if [ ! -f "$WIREMOCK_JAR" ]; then
     mkdir -p "${VENDOR_DIR}" && cd "${VENDOR_DIR}"
-    curl -O -J "http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
+    curl -O -J "https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
     cd ..
 fi
 


### PR DESCRIPTION
#### Proposed Changes
Uses HTTPS to download the wiremock standalone `jar` file – looks like maven doesn't want us using HTTP anymore.

#### To Test
Try downloading http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.23.2/wiremock-standalone-2.23.2.jar. See that you get a `501 HTTPS Required` error.

Try downloading https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.23.2/wiremock-standalone-2.23.2.jar. See that it succeeds.

cc @wordpress-mobile/platform-9 
