### PR TITLE
Update cocoapods to the latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org' do
-  gem 'cocoapods', '1.7.5'
+  gem 'cocoapods', '~> 1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.1)
+    CFPropertyList (3.0.2)
     activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    algoliasearch (1.27.1)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.0.3)
-    cocoapods (1.7.5)
+    cocoapods (1.8.4)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.7.5)
+      cocoapods-core (= 1.8.4)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-stats (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.3.1, < 2.0)
+      cocoapods-trunk (>= 1.4.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
@@ -27,13 +30,15 @@ GEM
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.10.0, < 2.0)
-    cocoapods-core (1.7.5)
+      xcodeproj (>= 1.11.1, < 2.0)
+    cocoapods-core (1.8.4)
       activesupport (>= 4.0.2, < 6)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.4)
-    cocoapods-downloader (1.2.2)
+    cocoapods-downloader (1.3.0)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -48,18 +53,20 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
+    httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    minitest (5.12.2)
+    json (2.3.0)
+    minitest (5.14.0)
     molinillo (0.6.6)
     nanaimo (0.2.6)
     nap (1.1.0)
     netrc (0.11.0)
     ruby-macho (1.4.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
-    xcodeproj (1.12.0)
+    xcodeproj (1.14.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -70,7 +77,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.7.5)!
+  cocoapods (~> 1)!
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
#### Proposed Changes
Updates CocoaPods to the latest version – this fixes a bug that was making it impossible to release a new version via the command line.

#### To Test
The only real way to test this would be to do a new release. You can try making a new release (on `develop`) by running `bundle exec pod trunk push` – it'll crash. If you try again on this branch, it'll fail saying "this version already exists" – that means the crash is fixed..

You can also see that this PR fixes the issue by taking a look at [the release I was able to do yesterday](https://github.com/wordpress-mobile/WordPressMocks/releases/tag/0.0.7) after applying this fix locally 😄 

cc @wordpress-mobile/platform-9 
