### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/WordPressMocks.podspec
+++ b/WordPressMocks.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = 'https://github.com/wordpress-mobile/WordPressMocks'
   s.license       = { type: 'GPLv2', file: 'LICENSE.md' }
-  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
+  s.author        = { "The WordPress Mobile Team" => "mobile@wordpress.org" }
 
   s.platform      = :ios
 

--- a/WordPressMocks.podspec
+++ b/WordPressMocks.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
 
   s.platform      = :ios
 
-  s.source        = { git: "https://github.com/wordpress-mobile/WordPressMocks.git", :tag => s.version.to_s }
+  s.source        = { :git => "https://github.com/wordpress-mobile/WordPressMocks.git", :tag => s.version.to_s }
   s.preserve_paths = 'WordPressMocks/src', 'scripts'
 end

--- a/WordPressMocks.podspec
+++ b/WordPressMocks.podspec
@@ -1,11 +1,19 @@
 Pod::Spec.new do |s|
-  s.name           = 'WordPressMocks'
-  s.version        = '0.0.9'
-  s.platform       = :ios
-  s.summary        = 'Network mocking for testing the WordPress mobile apps.'
-  s.homepage       = 'https://github.com/wordpress-mobile/WordPressMocks'
-  s.license        = { type: 'GPLv2', file: 'LICENSE.md' }
-  s.author         = { 'James Treanor' => 'jtreanor3@gmail.com' }
-  s.source         = { git: "https://github.com/wordpress-mobile/WordPressMocks.git", :tag => s.version.to_s }
+  s.name          = 'WordPressMocks'
+  s.version       = '0.0.9'
+
+  s.summary       = 'Network mocking for testing the WordPress mobile apps.'
+  s.description   = <<-DESC
+                    This framework contains a pack of icons – mainly ones used in the WordPress apps –
+                    that can be reused and scaled at any resolution.
+                  DESC
+
+  s.homepage      = 'https://github.com/wordpress-mobile/WordPressMocks'
+  s.license       = { type: 'GPLv2', file: 'LICENSE.md' }
+  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
+
+  s.platform      = :ios
+
+  s.source        = { git: "https://github.com/wordpress-mobile/WordPressMocks.git", :tag => s.version.to_s }
   s.preserve_paths = 'WordPressMocks/src', 'scripts'
 end


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

See wordpress-mobile/WordPressAuthenticator-iOS#582 for the rules I decided to follow on the format and content standardization.