### PR TITLE
Update Jetpack me/sites stub filters parameter

### DIFF
--- a/WordPressMocks.podspec
+++ b/WordPressMocks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'WordPressMocks'
-  s.version       = '0.0.10'
+  s.version       = '0.0.11'
 
   s.summary       = 'Network mocking for testing the WordPress mobile apps.'
   s.description   = <<-DESC

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/jetpack_rest_v11_me_sites.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/jetpack_rest_v11_me_sites.json
@@ -5,7 +5,7 @@
         "urlPathPattern": "/rest/v1.(1|2)/me/sites",
         "queryParameters": {
             "filters": {
-                "equalTo": "jetpack"
+                "matches": "jetpack(.*)"
             },
             "locale": {
                 "matches": "(.*)"


### PR DESCRIPTION
#### Proposed Changes

This PR updates the `filters` parameter in the Jetpack `me/sites` stub to use `matches` instead of `equals`. 

[Returning atomic sites when the Jetpack filter is applied](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/397) broke the JetpackScreenshotGeneration UI test. This PR fixes this by by using `matches`, which will let us match query parameters like `filters=jetpack, atomic` as well as `filters=jetpack`.

#### To Test

<!-- Please include instructions for testing these changes on both WordPress apps.
     This can be a link to a PR in that app's repo using the proposed changes.  -->

* WordPress iOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/16488

cc @wordpress-mobile/platform-9 
