### PR TITLE
Add Reusable block mock

### DIFF
--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/blocks/blocks.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/blocks/blocks.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "urlPattern": "/wp/v2/sites/.*/blocks.*",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": [],
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-cache, must-revalidate, max-age=0"
+    }
+  }
+}


### PR DESCRIPTION
#### Proposed Changes
Gutenberg now enables Reusable blocks for WPCom accounts. This means a request for the current site's Reusable blocks is made when the editor launches. Without this mock, the iOS UI tests fail due to an empty response from the API.

<details><summary>Crash Screenshot</summary>

<img width="371" alt="Screen Shot 2021-05-28 at 12 05 44" src="https://user-images.githubusercontent.com/438664/120025330-23c50680-bfb6-11eb-8065-86dc09d3a2fb.png">

</details>

<details><summary>WireMock Log Before: Non-Matched Request</summary >

<img width="1077" alt="wiremock-log-missing-mock" src="https://user-images.githubusercontent.com/438664/120025255-08f29200-bfb6-11eb-87ca-6e2bd46ce06e.png">

</details>

<details><summary>Test Before</summary >

https://user-images.githubusercontent.com/438664/120025127-d779c680-bfb5-11eb-9eb7-b0e5a2a93466.mov

</details>

<details><summary>Test After</summary >

https://user-images.githubusercontent.com/438664/120027548-1eb58680-bfb9-11eb-8cb0-c60f379a8722.mov

</details>

#### To Test

* WordPress Android: Due to no actively failing CI checks I believe this to be n/a.
* WordPress iOS: Run the `WordpressUITests` tests for WPiOS. 

cc @wordpress-mobile/platform-9 
