### PR TITLE
Use dynamic dates in Jetpack screenshots

### DIFF
--- a/WordPressMocks.podspec
+++ b/WordPressMocks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'WordPressMocks'
-  s.version       = '0.0.12'
+  s.version       = '0.0.13'
 
   s.summary       = 'Network mocking for testing the WordPress mobile apps.'
   s.description   = <<-DESC

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/activity/wpcom_v2_site_activity.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/activity/wpcom_v2_site_activity.json
@@ -38,7 +38,7 @@
                             "name": "Jetpack"
                         },
                         "type": "Announce",
-                        "published": "2021-05-06T06:23:10.798+00:00",
+                        "published": "{{now format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -79,7 +79,7 @@
                             "name": "Jetpack"
                         },
                         "type": "Announce",
-                        "published": "2021-05-06T06:23:05.356+00:00",
+                        "published": "{{now format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -120,7 +120,7 @@
                             "name": "Jetpack"
                         },
                         "type": "Announce",
-                        "published": "2021-05-06T06:22:58.776+00:00",
+                        "published": "{{now format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -170,7 +170,7 @@
                             "role": "administrator"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T15:59:23.139+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -213,7 +213,7 @@
                             "role": "administrator"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T14:52:03.207+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -259,7 +259,7 @@
                             "role": "administrator"
                         },
                         "type": "Update",
-                        "published": "2021-05-05T14:52:03.207+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -317,7 +317,7 @@
                             "role": "administrator"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T14:51:27.222+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -376,7 +376,7 @@
                             "role": "administrator"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T14:51:27.222+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -428,7 +428,7 @@
                             "role": "administrator"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T14:51:27.222+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -476,7 +476,7 @@
                             "role": "administrator"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T14:51:16.865+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -531,7 +531,7 @@
                             "role": "administrator"
                         },
                         "type": "Join",
-                        "published": "2021-05-05T14:50:55.428+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -560,7 +560,7 @@
                             "name": "Jetpack"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T13:58:59.141+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -590,7 +590,7 @@
                             "name": "Jetpack"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T13:58:32.797+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -620,7 +620,7 @@
                             "name": "Jetpack"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T13:58:02.881+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -673,7 +673,7 @@
                             "role": ""
                         },
                         "type": "Update",
-                        "published": "2021-05-05T14:26:16.327+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945
@@ -706,7 +706,7 @@
                             "name": "Jetpack"
                         },
                         "type": "Announce",
-                        "published": "2021-05-05T13:55:44.830+00:00",
+                        "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
                         "generator": {
                             "jetpack_version": 9.7,
                             "blog_id": 185124945

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/scan/wpcom_v2_sites_185124945_scan.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/scan/wpcom_v2_sites_185124945_scan.json
@@ -18,7 +18,7 @@
             ],
             "most_recent": {
                 "is_initial": false,
-                "timestamp": "2021-05-06T06:22:53+00:00",
+                "timestamp": "{{now offset='-2 days' format='yyyy-MM-dd'}}T{{now offset='-2 days' format='HH:mm:ssZ'}}",
                 "duration": 16,
                 "progress": 100,
                 "error": false


### PR DESCRIPTION
#### Proposed Changes

This PR updates the activity log json and scan json to use dynamic dates via [response templating](http://wiremock.org/docs/response-templating/).

Response templating allows us to specify relative/dynamic dates (like today, yesterday) instead of an arbitrary date (like May 6, 2021).

Note: I couldn't figure out how to escape the `'T'` in the iso8601 date format, so I'm using [this solution](https://stackoverflow.com/a/64041111) I found on SO.

Date formats, for reference:
- Activity log: `yyyy-MM-dd'T'HH:mm:ss.SSSZ`
- Scan: `yyyy-MM-dd'T'HH:mm:ssZ`

Activity Log | Scan | Jetpack Backup
:--: | :--: | :--:
Today and yesterday | Yesterday | Today
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-04 at 17 13 19](https://user-images.githubusercontent.com/6711616/120769572-3c09c800-c558-11eb-8b68-d1b234bb633e.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-04 at 17 13 25](https://user-images.githubusercontent.com/6711616/120769576-3d3af500-c558-11eb-93da-f033f14ff637.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-04 at 17 13 32](https://user-images.githubusercontent.com/6711616/120769581-3dd38b80-c558-11eb-95e0-a2bd156ccb0f.png)

 

#### To Test

<!-- Please include instructions for testing these changes on both WordPress apps.
     This can be a link to a PR in that app's repo using the proposed changes.  -->

* WordPress iOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/16634

cc @wordpress-mobile/platform-9 
