### PR TITLE
Add `organization_id` value to WP.com `/me/sites` stub

### DIFF
--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_sites.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_sites.json
@@ -65,6 +65,7 @@
                       "single_user_site": false,
                       "is_vip": false,
                       "is_following": false,
+                      "organization_id": 0,
                       "options": {
                         "timezone": "America\/Los_Angeles",
                         "gmt_offset": -7,
@@ -209,6 +210,7 @@
                       "single_user_site": false,
                       "is_vip": false,
                       "is_following": false,
+                      "organization_id": 0,
                       "options": {
                         "timezone": "America\/Los_Angeles",
                         "gmt_offset": -7,
@@ -353,6 +355,7 @@
                       "single_user_site": true,
                       "is_vip": false,
                       "is_following": true,
+                      "organization_id": 0,
                       "options": {
                         "timezone": "",
                         "gmt_offset": 0,


### PR DESCRIPTION
Relates to the changes in:

- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/445
- https://github.com/wordpress-mobile/WordPress-iOS/pull/17154

By looking at the changes in the PRs listed above, I'm guessing `organization_id` has been in the response from the live API for a while, but we never updated this particular mock response because we hadn't needed the value till now.

In fact, I noticed that the Jetpack `/me/sites` version does include `organization_id`, so we can say that the value had been in the response at least since May 2021. See https://github.com/wordpress-mobile/WordPressMocks/commit/caa9d47f8e3e26bfc087e8b60379c514feba77bf

#### To Test

See https://github.com/wordpress-mobile/WordPress-iOS/pull/17177 and notice that the UI tests pass in both Buildkite and CircleCI. The reason for the failures we've seen before this was that the tests crashed when trying to assign the `nil` value stored in the `organizationId` property serialized from the stub response that didn't include the key.