### PR TITLE
Added a recently required mock file

### DIFF
--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_106707880_dashboard_cards.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_106707880_dashboard_cards.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/wpcom/v2/sites/(.*)/dashboard/cards/\\?_locale=(.*)"
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "data": null
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive"
+    }
+  }
+}

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_106707880_dashboard_cards.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_106707880_dashboard_cards.json
@@ -6,7 +6,11 @@
   "response": {
     "status": 200,
     "jsonBody": {
-      "data": null
+        "posts": {
+            "has_published": true,
+            "draft": [],
+            "scheduled": []
+        }
     },
     "headers": {
       "Content-Type": "application/json",

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_106707880_dashboard_cards.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_106707880_dashboard_cards.json
@@ -2,7 +2,6 @@
   "request": {
     "method": "GET",
     "urlPattern": "/wpcom/v2/sites/(.*)/dashboard/cards/\\?_locale=(.*)"
-    }
   },
   "response": {
     "status": 200,


### PR DESCRIPTION
#### Proposed Changes
As mentioned in p1638528593435200-slack-CC7L49W13, a recently introduced endpoint caused WordPress Android tests to [fail](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/27895/workflows/366b1eeb-d69d-424e-90ac-9c5aa046f579/jobs/117429) on CI. 

As can be seen from the log, the reason for tests fail was a complaint from WireMock server about unmatched request.

Since WireMock server stars as an embedded process in WP and Woo Android (opposed to standalone in respective iOS projects), the UI tests runner will take into account all complaints from WireMock about unmatched requests, and will fail the tests, even if the request unmatched in WireMock has nothing to do with tested functionality at all.


#### To Test

<!-- Please include instructions for testing these changes on both WordPress apps.
     This can be a link to a PR in that app's repo using the proposed changes.  -->

* WordPress Android: TBD.
* WordPress iOS: the unmatched request warning in itself does not make WPiOS tests to fail, so I see no reason to run these tests in this particular case.

cc @wordpress-mobile/platform-9